### PR TITLE
Add insurance claim object

### DIFF
--- a/flaskr/blueprints/views.py
+++ b/flaskr/blueprints/views.py
@@ -1,11 +1,25 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, redirect, url_for
+from flaskr.models import InsuranceClaim
+from flaskr.helper import generate_claim_id, generate_random_claim_cost
+from flaskr.extensions import db
 
 blueprint = Blueprint("base", __name__)
 
 
 @blueprint.route("/")
 def index():
-    return render_template("index.html")
+    allInsuranceClaims = InsuranceClaim.query.all()
+    return render_template("index.html", all_insurance_claims=allInsuranceClaims)
+
+
+@blueprint.route("/generate_random_claim")
+def generate_random_claim():
+    new_claim = InsuranceClaim(
+        claim_reference=generate_claim_id(), claim_cost=generate_random_claim_cost()
+    )
+    db.session.add(new_claim)
+    db.session.commit()
+    return redirect(url_for("base.index"))
 
 
 @blueprint.route("/contact")

--- a/flaskr/helper.py
+++ b/flaskr/helper.py
@@ -1,0 +1,12 @@
+import random
+from uuid import uuid4
+
+
+def generate_claim_id() -> str:
+    # Generates a random claim id based on the uuid module
+    return str(uuid4())
+
+
+def generate_random_claim_cost() -> float:
+    # Generates a random claim cost, in the range of 0 to 100 000
+    return random.random() * 1e5

--- a/flaskr/models.py
+++ b/flaskr/models.py
@@ -17,3 +17,9 @@ class User(db.Model):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str] = mapped_column(unique=True)
     email: Mapped[str]
+
+
+class InsuranceClaim(db.Model):
+    id: Mapped[int] = mapped_column(primary_key=True)
+    claim_reference: Mapped[str] = mapped_column(unique=True)
+    claim_cost: Mapped[float]

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -19,14 +19,15 @@
 
     <main role="main" class="container">
         <div class="container">
+            <h1 class="mt-5">Interview Case - Website! </h1>
             <div>
-                <hr style="padding-top: 100px;">
+                <hr style="mt-3">
                 {% block body %}
                 {% endblock %}
             </div>
         </div>
 
-    </main><!-- /.container -->
+    </main>
 
     <!-- Bootstrap core JavaScript
     ================================================== -->

--- a/flaskr/templates/index.html
+++ b/flaskr/templates/index.html
@@ -1,11 +1,16 @@
 {% extends 'base.html' %}
 
-{% block title%}Index Page{% endblock %}
+{% block title %}
+  Index Page
+{% endblock %}
 
 {% block body %}
-<div>
-    <h1>Content!</h1>
-    <p>Text</p>
-</div>
+  <div>
+    <h1>Content</h1>
+    <p>This is where the content for the page goes.</p>
+  </div>
 
+  {% for insurance_claim in all_insurance_claims %}
+    <p><strong>{{ insurance_claim.claim_reference }}</strong>: {{ insurance_claim.claim_cost }}</p></br>
+  {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This PR contains the following changes:

- Adding a new object to the data model: Insurance Claim
- Displaying all insurance claims registered on the index page
- Added an endpoint, `/generate_random_claim`, which generates a new insurance claim with made up of randomly generated values
- Some minor template adjustments